### PR TITLE
Add fetchMultiple function to account

### DIFF
--- a/src/accounts.ts
+++ b/src/accounts.ts
@@ -202,6 +202,50 @@ function genAccountFiles(
       ],
     })
 
+    // fetchMultiple
+    cls.addMethod({
+      isStatic: true,
+      isAsync: true,
+      name: "fetchMultiple",
+      parameters: [
+        {
+          name: "c",
+          type: "Connection",
+        },
+        {
+          name: "addresses",
+          type: "PublicKey[]",
+        },
+      ],
+      returnType: `Promise<(${name} | null)[]>`,
+      statements: [
+        (writer) => {
+          writer.writeLine(
+            "const infos = await c.getMultipleAccountsInfo(addresses)"
+          )
+          writer.blankLine()
+          writer.write("return infos.map((info) => ")
+          writer.inlineBlock(() => {
+            writer.write("if (info === null)")
+            writer.inlineBlock(() => {
+              writer.writeLine("return null")
+            })
+            writer.write("")
+
+            writer.write("if (!info.owner.equals(PROGRAM_ID))")
+            writer.inlineBlock(() => {
+              writer.writeLine(
+                `throw new Error("account doesn't belong to this program")`
+              )
+            })
+            writer.blankLine()
+            writer.writeLine("return this.decode(info.data)")
+          })
+          writer.write(")")
+        },
+      ],
+    })
+
     // decode
     cls.addMethod({
       isStatic: true,

--- a/src/accounts.ts
+++ b/src/accounts.ts
@@ -217,7 +217,7 @@ function genAccountFiles(
           type: "PublicKey[]",
         },
       ],
-      returnType: `Promise<(${name} | null)[]>`,
+      returnType: `Promise<Array<${name} | null>>`,
       statements: [
         (writer) => {
           writer.writeLine(

--- a/tests/example-program-gen/exp/accounts/State.ts
+++ b/tests/example-program-gen/exp/accounts/State.ts
@@ -170,6 +170,24 @@ export class State {
     return this.decode(info.data)
   }
 
+  static async fetchMultiple(
+    c: Connection,
+    addresses: PublicKey[]
+  ): Promise<Array<State | null>> {
+    const infos = await c.getMultipleAccountsInfo(addresses)
+
+    return infos.map((info) => {
+      if (info === null) {
+        return null
+      }
+      if (!info.owner.equals(PROGRAM_ID)) {
+        throw new Error("account doesn't belong to this program")
+      }
+
+      return this.decode(info.data)
+    })
+  }
+
   static decode(data: Buffer): State {
     if (!data.slice(0, 8).equals(State.discriminator)) {
       throw new Error("invalid account discriminator")

--- a/tests/test.ts
+++ b/tests/test.ts
@@ -223,6 +223,47 @@ test("init and account fetch", async () => {
   }
 })
 
+
+test("fetch multiple", async () => {
+  const state = new Keypair()
+  const another_state = new Keypair()
+  const non_state = new Keypair()
+
+  const tx = new Transaction({ feePayer: payer.publicKey })
+  tx.add(
+    initialize({
+      state: state.publicKey,
+      payer: payer.publicKey,
+      nested: {
+        clock: SYSVAR_CLOCK_PUBKEY,
+        rent: SYSVAR_RENT_PUBKEY,
+      },
+      systemProgram: SystemProgram.programId,
+    })
+  )
+  tx.add(
+    initialize({
+      state: another_state.publicKey,
+      payer: payer.publicKey,
+      nested: {
+        clock: SYSVAR_CLOCK_PUBKEY,
+        rent: SYSVAR_RENT_PUBKEY,
+      },
+      systemProgram: SystemProgram.programId,
+    })
+  )
+
+  await sendAndConfirmTransaction(c, tx, [state, another_state, payer])
+
+  const res = await State.fetchMultiple(c, [
+    state.publicKey,
+    non_state.publicKey,
+    another_state.publicKey,
+  ])
+
+  expect(res).toEqual([expect.any(State), null, expect.any(State)])
+})
+
 test("instruction with args", async () => {
   const state = new Keypair()
 

--- a/tests/test.ts
+++ b/tests/test.ts
@@ -223,7 +223,6 @@ test("init and account fetch", async () => {
   }
 })
 
-
 test("fetch multiple", async () => {
   const state = new Keypair()
   const another_state = new Keypair()


### PR DESCRIPTION
Closes #3 

Adds a `fetchMultiple(connection, addresses)` function to account to allow efficient loading of accounts. 