### PR TITLE
CI: add solana version to rust cache

### DIFF
--- a/.github/actions/setup-solana/action.yaml
+++ b/.github/actions/setup-solana/action.yaml
@@ -11,8 +11,7 @@ runs:
           ~/.cache/solana/
           ~/.local/share/solana/
         key: solana-${{ runner.os }}-v0000-${{ env.SOLANA_CLI_VERSION }}
-    - if: steps.cache-solana.outputs.cache-hit != 'true'
-      run: sh -c "$(curl -sSfL https://release.solana.com/v${{ env.SOLANA_CLI_VERSION }}/install)"
+    - run: sh -c "$(curl -sSfL https://release.solana.com/v${{ env.SOLANA_CLI_VERSION }}/install)"
       shell: bash
     - run: echo "/home/runner/.local/share/solana/install/active_release/bin" >> $GITHUB_PATH
       shell: bash

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -32,7 +32,6 @@ jobs:
             ./tests/example-program/target/
           key: cargo-${{ runner.os }}-cargo-build-${{ hashFiles('**/Cargo.lock') }}-${{ env.SOLANA_CLI_VERSION }}-v0000
       - uses: ./.github/actions/setup-solana/
-      - run: rustup toolchain list -v
       - run: yarn --frozen-lockfile
       - run: yarn build
       - uses: ./.github/actions/git-diff/

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -30,8 +30,9 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             ./tests/example-program/target/
-          key: cargo-${{ runner.os }}-cargo-build-${{ hashFiles('**/Cargo.lock') }}
+          key: cargo-${{ runner.os }}-cargo-build-${{ hashFiles('**/Cargo.lock') }}-${{ env.SOLANA_CLI_VERSION }}-v0000
       - uses: ./.github/actions/setup-solana/
+      - run: rustup toolchain list -v
       - run: yarn --frozen-lockfile
       - run: yarn build
       - uses: ./.github/actions/git-diff/


### PR DESCRIPTION
This is needed because building the program bpf depends on solana version, so we want to cache the build cache under the right key.