### PR TITLE
ci: stop using Cargo.toml in cargo cache key derivation

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -30,7 +30,7 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             ./tests/example-program/target/
-          key: cargo-${{ runner.os }}-cargo-build-${{ hashFiles('**/Cargo.lock', '**/Cargo.toml') }}-${{ env.SOLANA_CLI_VERSION }}-v0000
+          key: cargo-${{ runner.os }}-cargo-build-${{ hashFiles('**/Cargo.lock') }}-${{ env.SOLANA_CLI_VERSION }}-v0000
       - uses: ./.github/actions/setup-solana/
       - run: yarn --frozen-lockfile
       - run: yarn build


### PR DESCRIPTION
It's not needed because Cargo.lock is present now