### PR TITLE
feat: dependency inject programId with default value

### DIFF
--- a/examples/basic-2/generated-client/accounts/Counter.ts
+++ b/examples/basic-2/generated-client/accounts/Counter.ts
@@ -33,14 +33,15 @@ export class Counter {
 
   static async fetch(
     c: Connection,
-    address: PublicKey
+    address: PublicKey,
+    programId: PublicKey = PROGRAM_ID
   ): Promise<Counter | null> {
     const info = await c.getAccountInfo(address)
 
     if (info === null) {
       return null
     }
-    if (!info.owner.equals(PROGRAM_ID)) {
+    if (!info.owner.equals(programId)) {
       throw new Error("account doesn't belong to this program")
     }
 
@@ -49,7 +50,8 @@ export class Counter {
 
   static async fetchMultiple(
     c: Connection,
-    addresses: PublicKey[]
+    addresses: PublicKey[],
+    programId: PublicKey = PROGRAM_ID
   ): Promise<Array<Counter | null>> {
     const infos = await c.getMultipleAccountsInfo(addresses)
 
@@ -57,7 +59,7 @@ export class Counter {
       if (info === null) {
         return null
       }
-      if (!info.owner.equals(PROGRAM_ID)) {
+      if (!info.owner.equals(programId)) {
         throw new Error("account doesn't belong to this program")
       }
 

--- a/examples/basic-2/generated-client/errors/index.ts
+++ b/examples/basic-2/generated-client/errors/index.ts
@@ -1,3 +1,4 @@
+import { PublicKey } from "@solana/web3.js"
 import { PROGRAM_ID } from "../programId"
 import * as anchor from "./anchor"
 
@@ -17,7 +18,10 @@ function hasOwnProperty<X extends object, Y extends PropertyKey>(
 
 const errorRe = /Program (\w+) failed: custom program error: (\w+)/
 
-export function fromTxError(err: unknown): anchor.AnchorError | null {
+export function fromTxError(
+  err: unknown,
+  programId: PublicKey = PROGRAM_ID
+): anchor.AnchorError | null {
   if (
     typeof err !== "object" ||
     err === null ||
@@ -40,7 +44,7 @@ export function fromTxError(err: unknown): anchor.AnchorError | null {
   }
 
   const [programIdRaw, codeRaw] = firstMatch.slice(1)
-  if (programIdRaw !== PROGRAM_ID.toString()) {
+  if (programIdRaw !== programId.toString()) {
     return null
   }
 

--- a/examples/basic-2/generated-client/instructions/create.ts
+++ b/examples/basic-2/generated-client/instructions/create.ts
@@ -15,7 +15,11 @@ export interface CreateAccounts {
 
 export const layout = borsh.struct([borsh.publicKey("authority")])
 
-export function create(args: CreateArgs, accounts: CreateAccounts) {
+export function create(
+  args: CreateArgs,
+  accounts: CreateAccounts,
+  programId: PublicKey = PROGRAM_ID
+) {
   const keys: Array<AccountMeta> = [
     { pubkey: accounts.counter, isSigner: true, isWritable: true },
     { pubkey: accounts.user, isSigner: true, isWritable: true },
@@ -30,6 +34,6 @@ export function create(args: CreateArgs, accounts: CreateAccounts) {
     buffer
   )
   const data = Buffer.concat([identifier, buffer]).slice(0, 8 + len)
-  const ix = new TransactionInstruction({ keys, programId: PROGRAM_ID, data })
+  const ix = new TransactionInstruction({ keys, programId, data })
   return ix
 }

--- a/examples/basic-2/generated-client/instructions/increment.ts
+++ b/examples/basic-2/generated-client/instructions/increment.ts
@@ -8,13 +8,16 @@ export interface IncrementAccounts {
   authority: PublicKey
 }
 
-export function increment(accounts: IncrementAccounts) {
+export function increment(
+  accounts: IncrementAccounts,
+  programId: PublicKey = PROGRAM_ID
+) {
   const keys: Array<AccountMeta> = [
     { pubkey: accounts.counter, isSigner: false, isWritable: true },
     { pubkey: accounts.authority, isSigner: true, isWritable: false },
   ]
   const identifier = Buffer.from([11, 18, 104, 9, 104, 174, 59, 33])
   const data = identifier
-  const ix = new TransactionInstruction({ keys, programId: PROGRAM_ID, data })
+  const ix = new TransactionInstruction({ keys, programId, data })
   return ix
 }

--- a/examples/tic-tac-toe/generated-client/accounts/Game.ts
+++ b/examples/tic-tac-toe/generated-client/accounts/Game.ts
@@ -42,13 +42,17 @@ export class Game {
     this.state = fields.state
   }
 
-  static async fetch(c: Connection, address: PublicKey): Promise<Game | null> {
+  static async fetch(
+    c: Connection,
+    address: PublicKey,
+    programId: PublicKey = PROGRAM_ID
+  ): Promise<Game | null> {
     const info = await c.getAccountInfo(address)
 
     if (info === null) {
       return null
     }
-    if (!info.owner.equals(PROGRAM_ID)) {
+    if (!info.owner.equals(programId)) {
       throw new Error("account doesn't belong to this program")
     }
 
@@ -57,7 +61,8 @@ export class Game {
 
   static async fetchMultiple(
     c: Connection,
-    addresses: PublicKey[]
+    addresses: PublicKey[],
+    programId: PublicKey = PROGRAM_ID
   ): Promise<Array<Game | null>> {
     const infos = await c.getMultipleAccountsInfo(addresses)
 
@@ -65,7 +70,7 @@ export class Game {
       if (info === null) {
         return null
       }
-      if (!info.owner.equals(PROGRAM_ID)) {
+      if (!info.owner.equals(programId)) {
         throw new Error("account doesn't belong to this program")
       }
 

--- a/examples/tic-tac-toe/generated-client/errors/index.ts
+++ b/examples/tic-tac-toe/generated-client/errors/index.ts
@@ -1,3 +1,4 @@
+import { PublicKey } from "@solana/web3.js"
 import { PROGRAM_ID } from "../programId"
 import * as anchor from "./anchor"
 import * as custom from "./custom"
@@ -21,7 +22,8 @@ function hasOwnProperty<X extends object, Y extends PropertyKey>(
 const errorRe = /Program (\w+) failed: custom program error: (\w+)/
 
 export function fromTxError(
-  err: unknown
+  err: unknown,
+  programId: PublicKey = PROGRAM_ID
 ): custom.CustomError | anchor.AnchorError | null {
   if (
     typeof err !== "object" ||
@@ -45,7 +47,7 @@ export function fromTxError(
   }
 
   const [programIdRaw, codeRaw] = firstMatch.slice(1)
-  if (programIdRaw !== PROGRAM_ID.toString()) {
+  if (programIdRaw !== programId.toString()) {
     return null
   }
 

--- a/examples/tic-tac-toe/generated-client/instructions/play.ts
+++ b/examples/tic-tac-toe/generated-client/instructions/play.ts
@@ -15,7 +15,11 @@ export interface PlayAccounts {
 
 export const layout = borsh.struct([types.Tile.layout("tile")])
 
-export function play(args: PlayArgs, accounts: PlayAccounts) {
+export function play(
+  args: PlayArgs,
+  accounts: PlayAccounts,
+  programId: PublicKey = PROGRAM_ID
+) {
   const keys: Array<AccountMeta> = [
     { pubkey: accounts.game, isSigner: false, isWritable: true },
     { pubkey: accounts.player, isSigner: true, isWritable: false },
@@ -29,6 +33,6 @@ export function play(args: PlayArgs, accounts: PlayAccounts) {
     buffer
   )
   const data = Buffer.concat([identifier, buffer]).slice(0, 8 + len)
-  const ix = new TransactionInstruction({ keys, programId: PROGRAM_ID, data })
+  const ix = new TransactionInstruction({ keys, programId, data })
   return ix
 }

--- a/examples/tic-tac-toe/generated-client/instructions/setupGame.ts
+++ b/examples/tic-tac-toe/generated-client/instructions/setupGame.ts
@@ -16,7 +16,11 @@ export interface SetupGameAccounts {
 
 export const layout = borsh.struct([borsh.publicKey("playerTwo")])
 
-export function setupGame(args: SetupGameArgs, accounts: SetupGameAccounts) {
+export function setupGame(
+  args: SetupGameArgs,
+  accounts: SetupGameAccounts,
+  programId: PublicKey = PROGRAM_ID
+) {
   const keys: Array<AccountMeta> = [
     { pubkey: accounts.game, isSigner: true, isWritable: true },
     { pubkey: accounts.playerOne, isSigner: true, isWritable: true },
@@ -31,6 +35,6 @@ export function setupGame(args: SetupGameArgs, accounts: SetupGameAccounts) {
     buffer
   )
   const data = Buffer.concat([identifier, buffer]).slice(0, 8 + len)
-  const ix = new TransactionInstruction({ keys, programId: PROGRAM_ID, data })
+  const ix = new TransactionInstruction({ keys, programId, data })
   return ix
 }

--- a/src/accounts.ts
+++ b/src/accounts.ts
@@ -177,6 +177,11 @@ function genAccountFiles(
           name: "address",
           type: "PublicKey",
         },
+        {
+          name: "programId",
+          type: "PublicKey",
+          initializer: "PROGRAM_ID"
+        }
       ],
       returnType: `Promise<${name} | null>`,
       statements: [
@@ -187,7 +192,7 @@ function genAccountFiles(
           writer.inlineBlock(() => {
             writer.writeLine("return null")
           })
-          writer.write("if (!info.owner.equals(PROGRAM_ID))")
+          writer.write("if (!info.owner.equals(programId))")
           writer.inlineBlock(() => {
             writer.writeLine(
               `throw new Error("account doesn't belong to this program")`
@@ -213,6 +218,11 @@ function genAccountFiles(
           name: "addresses",
           type: "PublicKey[]",
         },
+        {
+          name: "programId",
+          type: "PublicKey",
+          initializer: "PROGRAM_ID"
+        }
       ],
       returnType: `Promise<Array<${name} | null>>`,
       statements: [
@@ -229,7 +239,7 @@ function genAccountFiles(
             })
             writer.write("")
 
-            writer.write("if (!info.owner.equals(PROGRAM_ID))")
+            writer.write("if (!info.owner.equals(programId))")
             writer.inlineBlock(() => {
               writer.writeLine(
                 `throw new Error("account doesn't belong to this program")`

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -26,7 +26,9 @@ export function genIndex(
   })
 
   const hasCustomErrors = idl.errors && idl.errors.length > 0
-
+  src.addStatements([
+    `import { PublicKey } from "@solana/web3.js"`,
+  ]);
   src.addImportDeclaration({
     namedImports: ["PROGRAM_ID"],
     moduleSpecifier: "../programId",
@@ -112,6 +114,11 @@ export function genIndex(
         name: "err",
         type: "unknown",
       },
+      {
+        name: "programId",
+        type: "PublicKey",
+        initializer: "PROGRAM_ID"
+      }
     ],
     returnType: hasCustomErrors
       ? "custom.CustomError | anchor.AnchorError | null"
@@ -139,7 +146,7 @@ if (firstMatch === null) {
 }
 
 const [programIdRaw, codeRaw] = firstMatch.slice(1)
-if (programIdRaw !== PROGRAM_ID.toString()) {
+if (programIdRaw !== programId.toString()) {
   return null
 }
 

--- a/src/instructions.ts
+++ b/src/instructions.ts
@@ -183,6 +183,11 @@ function genInstructionFiles(
         type: accountsInterfaceName(ix.name),
       })
     }
+    ixFn.addParameter({
+        name: "programId",
+        type: "PublicKey",
+        initializer: "PROGRAM_ID"
+      });
 
     // keys
     ixFn.addVariableStatement({
@@ -289,7 +294,7 @@ function genInstructionFiles(
         {
           name: "ix",
           initializer:
-            "new TransactionInstruction({ keys, programId: PROGRAM_ID, data })",
+            "new TransactionInstruction({ keys, programId, data })",
         },
       ],
     })

--- a/tests/example-program-gen/exp/accounts/State.ts
+++ b/tests/example-program-gen/exp/accounts/State.ts
@@ -161,13 +161,17 @@ export class State {
     this.enumField4 = fields.enumField4
   }
 
-  static async fetch(c: Connection, address: PublicKey): Promise<State | null> {
+  static async fetch(
+    c: Connection,
+    address: PublicKey,
+    programId: PublicKey = PROGRAM_ID
+  ): Promise<State | null> {
     const info = await c.getAccountInfo(address)
 
     if (info === null) {
       return null
     }
-    if (!info.owner.equals(PROGRAM_ID)) {
+    if (!info.owner.equals(programId)) {
       throw new Error("account doesn't belong to this program")
     }
 
@@ -176,7 +180,8 @@ export class State {
 
   static async fetchMultiple(
     c: Connection,
-    addresses: PublicKey[]
+    addresses: PublicKey[],
+    programId: PublicKey = PROGRAM_ID
   ): Promise<Array<State | null>> {
     const infos = await c.getMultipleAccountsInfo(addresses)
 
@@ -184,7 +189,7 @@ export class State {
       if (info === null) {
         return null
       }
-      if (!info.owner.equals(PROGRAM_ID)) {
+      if (!info.owner.equals(programId)) {
         throw new Error("account doesn't belong to this program")
       }
 

--- a/tests/example-program-gen/exp/accounts/State2.ts
+++ b/tests/example-program-gen/exp/accounts/State2.ts
@@ -29,14 +29,15 @@ export class State2 {
 
   static async fetch(
     c: Connection,
-    address: PublicKey
+    address: PublicKey,
+    programId: PublicKey = PROGRAM_ID
   ): Promise<State2 | null> {
     const info = await c.getAccountInfo(address)
 
     if (info === null) {
       return null
     }
-    if (!info.owner.equals(PROGRAM_ID)) {
+    if (!info.owner.equals(programId)) {
       throw new Error("account doesn't belong to this program")
     }
 
@@ -45,7 +46,8 @@ export class State2 {
 
   static async fetchMultiple(
     c: Connection,
-    addresses: PublicKey[]
+    addresses: PublicKey[],
+    programId: PublicKey = PROGRAM_ID
   ): Promise<Array<State2 | null>> {
     const infos = await c.getMultipleAccountsInfo(addresses)
 
@@ -53,7 +55,7 @@ export class State2 {
       if (info === null) {
         return null
       }
-      if (!info.owner.equals(PROGRAM_ID)) {
+      if (!info.owner.equals(programId)) {
         throw new Error("account doesn't belong to this program")
       }
 

--- a/tests/example-program-gen/exp/errors/index.ts
+++ b/tests/example-program-gen/exp/errors/index.ts
@@ -1,3 +1,4 @@
+import { PublicKey } from "@solana/web3.js"
 import { PROGRAM_ID } from "../programId"
 import * as anchor from "./anchor"
 import * as custom from "./custom"
@@ -21,7 +22,8 @@ function hasOwnProperty<X extends object, Y extends PropertyKey>(
 const errorRe = /Program (\w+) failed: custom program error: (\w+)/
 
 export function fromTxError(
-  err: unknown
+  err: unknown,
+  programId: PublicKey = PROGRAM_ID
 ): custom.CustomError | anchor.AnchorError | null {
   if (
     typeof err !== "object" ||
@@ -45,7 +47,7 @@ export function fromTxError(
   }
 
   const [programIdRaw, codeRaw] = firstMatch.slice(1)
-  if (programIdRaw !== PROGRAM_ID.toString()) {
+  if (programIdRaw !== programId.toString()) {
     return null
   }
 

--- a/tests/example-program-gen/exp/instructions/causeError.ts
+++ b/tests/example-program-gen/exp/instructions/causeError.ts
@@ -4,10 +4,10 @@ import * as borsh from "@coral-xyz/borsh" // eslint-disable-line @typescript-esl
 import * as types from "../types" // eslint-disable-line @typescript-eslint/no-unused-vars
 import { PROGRAM_ID } from "../programId"
 
-export function causeError() {
+export function causeError(programId: PublicKey = PROGRAM_ID) {
   const keys: Array<AccountMeta> = []
   const identifier = Buffer.from([67, 104, 37, 17, 2, 155, 68, 17])
   const data = identifier
-  const ix = new TransactionInstruction({ keys, programId: PROGRAM_ID, data })
+  const ix = new TransactionInstruction({ keys, programId, data })
   return ix
 }

--- a/tests/example-program-gen/exp/instructions/initialize.ts
+++ b/tests/example-program-gen/exp/instructions/initialize.ts
@@ -16,7 +16,10 @@ export interface InitializeAccounts {
   systemProgram: PublicKey
 }
 
-export function initialize(accounts: InitializeAccounts) {
+export function initialize(
+  accounts: InitializeAccounts,
+  programId: PublicKey = PROGRAM_ID
+) {
   const keys: Array<AccountMeta> = [
     { pubkey: accounts.state, isSigner: true, isWritable: true },
     { pubkey: accounts.nested.clock, isSigner: false, isWritable: false },
@@ -26,6 +29,6 @@ export function initialize(accounts: InitializeAccounts) {
   ]
   const identifier = Buffer.from([175, 175, 109, 31, 13, 152, 155, 237])
   const data = identifier
-  const ix = new TransactionInstruction({ keys, programId: PROGRAM_ID, data })
+  const ix = new TransactionInstruction({ keys, programId, data })
   return ix
 }

--- a/tests/example-program-gen/exp/instructions/initializeWithValues.ts
+++ b/tests/example-program-gen/exp/instructions/initializeWithValues.ts
@@ -77,7 +77,8 @@ export const layout = borsh.struct([
 /** Initializes an account with specified values */
 export function initializeWithValues(
   args: InitializeWithValuesArgs,
-  accounts: InitializeWithValuesAccounts
+  accounts: InitializeWithValuesAccounts,
+  programId: PublicKey = PROGRAM_ID
 ) {
   const keys: Array<AccountMeta> = [
     { pubkey: accounts.state, isSigner: true, isWritable: true },
@@ -129,6 +130,6 @@ export function initializeWithValues(
     buffer
   )
   const data = Buffer.concat([identifier, buffer]).slice(0, 8 + len)
-  const ix = new TransactionInstruction({ keys, programId: PROGRAM_ID, data })
+  const ix = new TransactionInstruction({ keys, programId, data })
   return ix
 }

--- a/tests/example-program-gen/exp/instructions/initializeWithValues2.ts
+++ b/tests/example-program-gen/exp/instructions/initializeWithValues2.ts
@@ -24,7 +24,8 @@ export const layout = borsh.struct([
  */
 export function initializeWithValues2(
   args: InitializeWithValues2Args,
-  accounts: InitializeWithValues2Accounts
+  accounts: InitializeWithValues2Accounts,
+  programId: PublicKey = PROGRAM_ID
 ) {
   const keys: Array<AccountMeta> = [
     { pubkey: accounts.state, isSigner: true, isWritable: true },
@@ -40,6 +41,6 @@ export function initializeWithValues2(
     buffer
   )
   const data = Buffer.concat([identifier, buffer]).slice(0, 8 + len)
-  const ix = new TransactionInstruction({ keys, programId: PROGRAM_ID, data })
+  const ix = new TransactionInstruction({ keys, programId, data })
   return ix
 }


### PR DESCRIPTION
This PR addresses the concerns in #51 and allows callers to specify their own dynamic programId. If no programId is specified then the default value from `programId.ts` is used. 

This feature will allow callers to decouple their internal management of their programId's from the generated code files from `anchor-client-gen`, making `anchor-client-ge`n completely transparent to the integrating project, but still maintains backwards compatibility with the existing API.


example:
```typescript
  static async fetch(
    c: Connection,
    address: PublicKey,
    programId: PublicKey = PROGRAM_ID
  ): Promise<Counter | null> {
    const info = await c.getAccountInfo(address)

    if (info === null) {
      return null
    }
    if (!info.owner.equals(programId)) {
      throw new Error("account doesn't belong to this program")
    }

    return this.decode(info.data)
  }
```