### PR TITLE
instructions with optional accounts

### DIFF
--- a/src/instructions.ts
+++ b/src/instructions.ts
@@ -113,6 +113,9 @@ function genInstructionFiles(
     ) {
       if (!("accounts" in accItem)) {
         writer.write("PublicKey")
+        if (accItem.isOptional) {
+          writer.write(" | null")
+        }
         return
       }
       writer.block(() => {
@@ -211,7 +214,7 @@ function genInstructionFiles(
                 writer.writeLine(
                   `{ pubkey: accounts.${[...nestedNames, item.name].join(
                     "."
-                  )}, isSigner: ${item.isSigner}, isWritable: ${item.isMut} },`
+                  )}${item.isOptional ? " ?? PROGRAM_ID" : ""}, isSigner: ${item.isSigner}, isWritable: ${item.isMut} },`
                 )
               })
             }

--- a/tests/example-program-gen/exp/instructions/index.ts
+++ b/tests/example-program-gen/exp/instructions/index.ts
@@ -11,3 +11,5 @@ export type {
   InitializeWithValues2Accounts,
 } from "./initializeWithValues2"
 export { causeError } from "./causeError"
+export { optional } from "./optional"
+export type { OptionalArgs, OptionalAccounts } from "./optional"

--- a/tests/example-program-gen/exp/instructions/optional.ts
+++ b/tests/example-program-gen/exp/instructions/optional.ts
@@ -1,0 +1,40 @@
+import { TransactionInstruction, PublicKey, AccountMeta } from "@solana/web3.js" // eslint-disable-line @typescript-eslint/no-unused-vars
+import BN from "bn.js" // eslint-disable-line @typescript-eslint/no-unused-vars
+import * as borsh from "@coral-xyz/borsh" // eslint-disable-line @typescript-eslint/no-unused-vars
+import * as types from "../types" // eslint-disable-line @typescript-eslint/no-unused-vars
+import { PROGRAM_ID } from "../programId"
+
+export interface OptionalArgs {
+  name: string
+}
+
+export interface OptionalAccounts {
+  state: PublicKey | null
+  payer: PublicKey
+  systemProgram: PublicKey
+}
+
+export const layout = borsh.struct([borsh.str("name")])
+
+export function optional(
+  args: OptionalArgs,
+  accounts: OptionalAccounts,
+  programId: PublicKey = PROGRAM_ID
+) {
+  const keys: Array<AccountMeta> = [
+    { pubkey: accounts.state ?? PROGRAM_ID, isSigner: false, isWritable: true },
+    { pubkey: accounts.payer, isSigner: true, isWritable: true },
+    { pubkey: accounts.systemProgram, isSigner: false, isWritable: false },
+  ]
+  const identifier = Buffer.from([199, 182, 147, 252, 17, 246, 54, 225])
+  const buffer = Buffer.alloc(1000)
+  const len = layout.encode(
+    {
+      name: args.name,
+    },
+    buffer
+  )
+  const data = Buffer.concat([identifier, buffer]).slice(0, 8 + len)
+  const ix = new TransactionInstruction({ keys, programId, data })
+  return ix
+}

--- a/tests/example-program-gen/idl.json
+++ b/tests/example-program-gen/idl.json
@@ -262,6 +262,33 @@
       "name": "causeError",
       "accounts": [],
       "args": []
+    },
+    {
+      "name": "optional",
+      "accounts": [
+        {
+          "name": "state",
+          "isMut": true,
+          "isSigner": false,
+          "isOptional": true
+        },
+        {
+          "name": "payer",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "name",
+          "type": "string"
+        }
+      ]
     }
   ],
   "accounts": [

--- a/tests/example-program/programs/example-program/src/lib.rs
+++ b/tests/example-program/programs/example-program/src/lib.rs
@@ -89,6 +89,10 @@ pub mod example_program {
     pub fn cause_error(_ctx: Context<CauseError>) -> Result<()> {
         return Err(error!(ErrorCode::SomeError));
     }
+
+    pub fn optional(_ctx: Context<Optional>, _name: String) -> Result<()> {
+        Ok(())
+    }
 }
 
 /// Enum type
@@ -275,6 +279,23 @@ pub struct Initialize2<'info> {
 
 #[derive(Accounts)]
 pub struct CauseError {}
+
+#[derive(Accounts)]
+#[instruction(name:String)]
+pub struct Optional<'info> {
+    #[account(
+        init,
+        space = 8 + 1000, // TODO: use exact space required
+        seeds = [b"optional", name.as_bytes()],
+        bump,
+        payer = payer
+    )]
+    state: Option<Account<'info, State>>,
+
+    #[account(mut)]
+    payer: Signer<'info>,
+    system_program: Program<'info, System>,
+}
 
 #[error_code]
 pub enum ErrorCode {

--- a/tests/test.ts
+++ b/tests/test.ts
@@ -20,6 +20,7 @@ import {
   initialize,
   initializeWithValues,
   initializeWithValues2,
+  optional,
 } from "./example-program-gen/act/instructions"
 import { BarStruct, FooStruct } from "./example-program-gen/act/types"
 import {
@@ -29,6 +30,7 @@ import {
   Unnamed,
 } from "./example-program-gen/act/types/FooEnum"
 import * as path from "path"
+import { PROGRAM_ID } from "./example-program-gen/act/programId"
 
 const c = new Connection("http://127.0.0.1:8899", "processed")
 const faucet = JSON.parse(
@@ -536,6 +538,48 @@ it("instruction with args", async () => {
   // vecOfOption
   expect(res2.vecOfOption[0]).toBe(null)
   expect(res2.vecOfOption[1] !== null && res2.vecOfOption[1].eqn(20)).toBe(true)
+})
+
+it("optional with specified account", async () => {
+  const name = 'with-specified-account'
+  const [state] = PublicKey.findProgramAddressSync([
+    Buffer.from("optional"), Buffer.from(name)
+  ], PROGRAM_ID)
+
+  const tx = new Transaction({ feePayer: payer.publicKey })
+  tx.add(
+    optional({name},{
+      state,
+      payer: payer.publicKey,
+      systemProgram: SystemProgram.programId,
+    })
+  )
+
+  await sendAndConfirmTransaction(c, tx, [payer])
+
+  const res = await State.fetch(c, state)
+  expect(res).not.toBe(null)
+})
+
+it("optional without specifying account", async () => {
+  const name = 'without-specifying-account'
+  const [state] = PublicKey.findProgramAddressSync([
+    Buffer.from("optional"), Buffer.from(name)
+  ], PROGRAM_ID)
+
+  const tx = new Transaction({ feePayer: payer.publicKey })
+  tx.add(
+    optional({name}, {
+      state: null,
+      payer: payer.publicKey,
+      systemProgram: SystemProgram.programId,
+    })
+  )
+
+  await sendAndConfirmTransaction(c, tx, [payer])
+
+  const res = await State.fetch(c, state)
+  expect(res).toBe(null)
 })
 
 it("tx error", async () => {


### PR DESCRIPTION
Add the ability to model instructions with accounts that are optional (Option<Account<'info, T>>), so we can specify them as `null` and the instruction method will fill in with the PROGRAM_ID address as Anchor expects for such optional accounts