### PR TITLE
Support variable accounts for instructions

### DIFF
--- a/examples/basic-2/generated-client/instructions/create.ts
+++ b/examples/basic-2/generated-client/instructions/create.ts
@@ -29,12 +29,14 @@ export const layout = borsh.struct([borshAddress("authority")])
 export function create(
   args: CreateArgs,
   accounts: CreateAccounts,
+  remainingAccounts: Array<IAccountMeta | IAccountSignerMeta> = [],
   programAddress: Address = PROGRAM_ID
 ) {
   const keys: Array<IAccountMeta | IAccountSignerMeta> = [
     { address: accounts.counter.address, role: 3, signer: accounts.counter },
     { address: accounts.user.address, role: 3, signer: accounts.user },
     { address: accounts.systemProgram, role: 0 },
+    ...remainingAccounts,
   ]
   const identifier = Buffer.from([24, 30, 200, 40, 5, 28, 7, 119])
   const buffer = Buffer.alloc(1000)

--- a/examples/basic-2/generated-client/instructions/increment.ts
+++ b/examples/basic-2/generated-client/instructions/increment.ts
@@ -21,6 +21,7 @@ export interface IncrementAccounts {
 
 export function increment(
   accounts: IncrementAccounts,
+  remainingAccounts: Array<IAccountMeta | IAccountSignerMeta> = [],
   programAddress: Address = PROGRAM_ID
 ) {
   const keys: Array<IAccountMeta | IAccountSignerMeta> = [
@@ -30,6 +31,7 @@ export function increment(
       role: 2,
       signer: accounts.authority,
     },
+    ...remainingAccounts,
   ]
   const identifier = Buffer.from([11, 18, 104, 9, 104, 174, 59, 33])
   const data = identifier

--- a/examples/tic-tac-toe/generated-client/instructions/play.ts
+++ b/examples/tic-tac-toe/generated-client/instructions/play.ts
@@ -29,11 +29,13 @@ export const layout = borsh.struct([types.Tile.layout("tile")])
 export function play(
   args: PlayArgs,
   accounts: PlayAccounts,
+  remainingAccounts: Array<IAccountMeta | IAccountSignerMeta> = [],
   programAddress: Address = PROGRAM_ID
 ) {
   const keys: Array<IAccountMeta | IAccountSignerMeta> = [
     { address: accounts.game, role: 1 },
     { address: accounts.player.address, role: 2, signer: accounts.player },
+    ...remainingAccounts,
   ]
   const identifier = Buffer.from([213, 157, 193, 142, 228, 56, 248, 150])
   const buffer = Buffer.alloc(1000)

--- a/examples/tic-tac-toe/generated-client/instructions/setupGame.ts
+++ b/examples/tic-tac-toe/generated-client/instructions/setupGame.ts
@@ -30,6 +30,7 @@ export const layout = borsh.struct([borshAddress("playerTwo")])
 export function setupGame(
   args: SetupGameArgs,
   accounts: SetupGameAccounts,
+  remainingAccounts: Array<IAccountMeta | IAccountSignerMeta> = [],
   programAddress: Address = PROGRAM_ID
 ) {
   const keys: Array<IAccountMeta | IAccountSignerMeta> = [
@@ -40,6 +41,7 @@ export function setupGame(
       signer: accounts.playerOne,
     },
     { address: accounts.systemProgram, role: 0 },
+    ...remainingAccounts,
   ]
   const identifier = Buffer.from([180, 218, 128, 75, 58, 222, 35, 82])
   const buffer = Buffer.alloc(1000)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "anchor-client-gen",
   "description": "A tool for generating solana web3 clients from anchor IDLs.",
-  "version": "1.29.0",
+  "version": "1.30.0",
   "bin": "dist/main.js",
   "license": "MIT",
   "homepage": "https://github.com/kklas/anchor-client-gen",

--- a/src/instructions.ts
+++ b/src/instructions.ts
@@ -198,6 +198,11 @@ function genInstructionFiles(
       })
     }
     ixFn.addParameter({
+      name: "remainingAccounts",
+      type: "Array<IAccountMeta | IAccountSignerMeta>",
+      initializer: "[]",
+    })
+    ixFn.addParameter({
       name: "programAddress",
       type: "Address",
       initializer: "PROGRAM_ID",
@@ -297,7 +302,12 @@ function genInstructionFiles(
               })
             }
 
+            function getRemainingAccounts() {
+              writer.writeLine("...remainingAccounts,")
+            }
+
             recurseAccounts(ix.accounts, [])
+            getRemainingAccounts()
 
             writer.write("]")
           },

--- a/tests/example-program-gen/exp/errors/custom.ts
+++ b/tests/example-program-gen/exp/errors/custom.ts
@@ -1,4 +1,8 @@
-export type CustomError = SomeError | OtherError | ErrorWithoutMsg
+export type CustomError =
+  | SomeError
+  | OtherError
+  | ErrorWithoutMsg
+  | RemainingAccountsMismatch
 
 export class SomeError extends Error {
   static readonly code = 6000
@@ -32,6 +36,17 @@ export class ErrorWithoutMsg extends Error {
   }
 }
 
+export class RemainingAccountsMismatch extends Error {
+  static readonly code = 6003
+  readonly code = 6003
+  readonly name = "RemainingAccountsMismatch"
+  readonly msg = "Remaining accounts mismatch."
+
+  constructor(readonly logs?: string[]) {
+    super("6003: Remaining accounts mismatch.")
+  }
+}
+
 export function fromCode(code: number, logs?: string[]): CustomError | null {
   switch (code) {
     case 6000:
@@ -40,6 +55,8 @@ export function fromCode(code: number, logs?: string[]): CustomError | null {
       return new OtherError(logs)
     case 6002:
       return new ErrorWithoutMsg(logs)
+    case 6003:
+      return new RemainingAccountsMismatch(logs)
   }
 
   return null

--- a/tests/example-program-gen/exp/instructions/causeError.ts
+++ b/tests/example-program-gen/exp/instructions/causeError.ts
@@ -15,8 +15,11 @@ import { borshAddress } from "../utils" // eslint-disable-line @typescript-eslin
 import * as types from "../types" // eslint-disable-line @typescript-eslint/no-unused-vars
 import { PROGRAM_ID } from "../programId"
 
-export function causeError(programAddress: Address = PROGRAM_ID) {
-  const keys: Array<IAccountMeta | IAccountSignerMeta> = []
+export function causeError(
+  remainingAccounts: Array<IAccountMeta | IAccountSignerMeta> = [],
+  programAddress: Address = PROGRAM_ID
+) {
+  const keys: Array<IAccountMeta | IAccountSignerMeta> = [...remainingAccounts]
   const identifier = Buffer.from([67, 104, 37, 17, 2, 155, 68, 17])
   const data = identifier
   const ix: IInstruction = { accounts: keys, programAddress, data }

--- a/tests/example-program-gen/exp/instructions/index.ts
+++ b/tests/example-program-gen/exp/instructions/index.ts
@@ -13,3 +13,5 @@ export type {
 export { causeError } from "./causeError"
 export { optional } from "./optional"
 export type { OptionalAccounts } from "./optional"
+export { remaining } from "./remaining"
+export type { RemainingArgs, RemainingAccounts } from "./remaining"

--- a/tests/example-program-gen/exp/instructions/initialize.ts
+++ b/tests/example-program-gen/exp/instructions/initialize.ts
@@ -29,6 +29,7 @@ export interface InitializeAccounts {
 
 export function initialize(
   accounts: InitializeAccounts,
+  remainingAccounts: Array<IAccountMeta | IAccountSignerMeta> = [],
   programAddress: Address = PROGRAM_ID
 ) {
   const keys: Array<IAccountMeta | IAccountSignerMeta> = [
@@ -37,6 +38,7 @@ export function initialize(
     { address: accounts.nested.rent, role: 0 },
     { address: accounts.payer.address, role: 3, signer: accounts.payer },
     { address: accounts.systemProgram, role: 0 },
+    ...remainingAccounts,
   ]
   const identifier = Buffer.from([175, 175, 109, 31, 13, 152, 155, 237])
   const data = identifier

--- a/tests/example-program-gen/exp/instructions/initializeWithValues.ts
+++ b/tests/example-program-gen/exp/instructions/initializeWithValues.ts
@@ -89,6 +89,7 @@ export const layout = borsh.struct([
 export function initializeWithValues(
   args: InitializeWithValuesArgs,
   accounts: InitializeWithValuesAccounts,
+  remainingAccounts: Array<IAccountMeta | IAccountSignerMeta> = [],
   programAddress: Address = PROGRAM_ID
 ) {
   const keys: Array<IAccountMeta | IAccountSignerMeta> = [
@@ -97,6 +98,7 @@ export function initializeWithValues(
     { address: accounts.nested.rent, role: 0 },
     { address: accounts.payer.address, role: 3, signer: accounts.payer },
     { address: accounts.systemProgram, role: 0 },
+    ...remainingAccounts,
   ]
   const identifier = Buffer.from([220, 73, 8, 213, 178, 69, 181, 141])
   const buffer = Buffer.alloc(1000)

--- a/tests/example-program-gen/exp/instructions/initializeWithValues2.ts
+++ b/tests/example-program-gen/exp/instructions/initializeWithValues2.ts
@@ -36,12 +36,14 @@ export const layout = borsh.struct([
 export function initializeWithValues2(
   args: InitializeWithValues2Args,
   accounts: InitializeWithValues2Accounts,
+  remainingAccounts: Array<IAccountMeta | IAccountSignerMeta> = [],
   programAddress: Address = PROGRAM_ID
 ) {
   const keys: Array<IAccountMeta | IAccountSignerMeta> = [
     { address: accounts.state.address, role: 3, signer: accounts.state },
     { address: accounts.payer.address, role: 3, signer: accounts.payer },
     { address: accounts.systemProgram, role: 0 },
+    ...remainingAccounts,
   ]
   const identifier = Buffer.from([248, 190, 21, 97, 239, 148, 39, 181])
   const buffer = Buffer.alloc(1000)

--- a/tests/example-program-gen/exp/instructions/optional.ts
+++ b/tests/example-program-gen/exp/instructions/optional.ts
@@ -27,6 +27,7 @@ export interface OptionalAccounts {
 
 export function optional(
   accounts: OptionalAccounts,
+  remainingAccounts: Array<IAccountMeta | IAccountSignerMeta> = [],
   programAddress: Address = PROGRAM_ID
 ) {
   const keys: Array<IAccountMeta | IAccountSignerMeta> = [
@@ -57,6 +58,7 @@ export function optional(
       : { address: programAddress, role: 0 },
     { address: accounts.payer.address, role: 3, signer: accounts.payer },
     { address: accounts.systemProgram, role: 0 },
+    ...remainingAccounts,
   ]
   const identifier = Buffer.from([199, 182, 147, 252, 17, 246, 54, 225])
   const data = identifier

--- a/tests/example-program-gen/exp/instructions/remaining.ts
+++ b/tests/example-program-gen/exp/instructions/remaining.ts
@@ -1,0 +1,51 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import {
+  Address,
+  isSome,
+  IAccountMeta,
+  IAccountSignerMeta,
+  IInstruction,
+  Option,
+  TransactionSigner,
+} from "@solana/kit"
+/* eslint-enable @typescript-eslint/no-unused-vars */
+import BN from "bn.js" // eslint-disable-line @typescript-eslint/no-unused-vars
+import * as borsh from "@coral-xyz/borsh" // eslint-disable-line @typescript-eslint/no-unused-vars
+import { borshAddress } from "../utils" // eslint-disable-line @typescript-eslint/no-unused-vars
+import * as types from "../types" // eslint-disable-line @typescript-eslint/no-unused-vars
+import { PROGRAM_ID } from "../programId"
+
+export interface RemainingArgs {
+  expectedRemainingAccounts: number
+}
+
+export interface RemainingAccounts {
+  payer: TransactionSigner
+  systemProgram: Address
+}
+
+export const layout = borsh.struct([borsh.u32("expectedRemainingAccounts")])
+
+export function remaining(
+  args: RemainingArgs,
+  accounts: RemainingAccounts,
+  remainingAccounts: Array<IAccountMeta | IAccountSignerMeta> = [],
+  programAddress: Address = PROGRAM_ID
+) {
+  const keys: Array<IAccountMeta | IAccountSignerMeta> = [
+    { address: accounts.payer.address, role: 3, signer: accounts.payer },
+    { address: accounts.systemProgram, role: 0 },
+    ...remainingAccounts,
+  ]
+  const identifier = Buffer.from([242, 61, 121, 163, 200, 48, 28, 21])
+  const buffer = Buffer.alloc(1000)
+  const len = layout.encode(
+    {
+      expectedRemainingAccounts: args.expectedRemainingAccounts,
+    },
+    buffer
+  )
+  const data = Buffer.concat([identifier, buffer]).slice(0, 8 + len)
+  const ix: IInstruction = { accounts: keys, programAddress, data }
+  return ix
+}

--- a/tests/example-program-gen/idl.json
+++ b/tests/example-program-gen/idl.json
@@ -307,6 +307,27 @@
         }
       ],
       "args": []
+    },
+    {
+      "name": "remaining",
+      "accounts": [
+        {
+          "name": "payer",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "expectedRemainingAccounts",
+          "type": "u32"
+        }
+      ]
     }
   ],
   "accounts": [
@@ -664,6 +685,11 @@
     {
       "code": 6002,
       "name": "ErrorWithoutMsg"
+    },
+    {
+      "code": 6003,
+      "name": "RemainingAccountsMismatch",
+      "msg": "Remaining accounts mismatch."
     }
   ]
 }

--- a/tests/example-program/programs/example-program/src/lib.rs
+++ b/tests/example-program/programs/example-program/src/lib.rs
@@ -340,6 +340,6 @@ pub enum ErrorCode {
     #[msg("Another error.")]
     OtherError,
     ErrorWithoutMsg,
-    #[msg("Remaining accounts mismatch")]
+    #[msg("Remaining accounts mismatch.")]
     RemainingAccountsMismatch,
 }

--- a/tests/example-program/programs/example-program/src/lib.rs
+++ b/tests/example-program/programs/example-program/src/lib.rs
@@ -99,6 +99,15 @@ pub mod example_program {
         });
         Ok(())
     }
+
+    pub fn remaining(ctx: Context<Remaining>, expected_remaining_accounts: u32) -> Result<()> {
+        let provided_remaining_accounts = ctx.remaining_accounts.len();
+        if provided_remaining_accounts != expected_remaining_accounts as usize {
+            Err(error!(ErrorCode::RemainingAccountsMismatch))
+        } else {
+            Ok(())
+        }
+    }
 }
 
 /// Enum type
@@ -317,6 +326,13 @@ pub struct Optional<'info> {
     system_program: Program<'info, System>,
 }
 
+#[derive(Accounts)]
+pub struct Remaining<'info> {
+    #[account(mut)]
+    payer: Signer<'info>,
+    system_program: Program<'info, System>,
+}
+
 #[error_code]
 pub enum ErrorCode {
     #[msg("Example error.")]
@@ -324,4 +340,6 @@ pub enum ErrorCode {
     #[msg("Another error.")]
     OtherError,
     ErrorWithoutMsg,
+    #[msg("Remaining accounts mismatch")]
+    RemainingAccountsMismatch,
 }

--- a/tests/test.ts
+++ b/tests/test.ts
@@ -1183,29 +1183,15 @@ it("remaining accounts should match", async () => {
   const remainingKeypair1 = await generateKeyPair()
   const remainingKeypair2 = await generateKeyPair()
 
-  const remainingAddress1 = await getAddressFromPublicKey(remainingKeypair1.publicKey)
-  const remainingAddress2 =  await getAddressFromPublicKey(remainingKeypair2.publicKey)
+  const remainingAddress1 = await getAddressFromPublicKey(
+    remainingKeypair1.publicKey
+  )
+  const remainingAddress2 = await getAddressFromPublicKey(
+    remainingKeypair2.publicKey
+  )
 
-  await sendTx(payer, [remaining(
-    {
-      expectedRemainingAccounts: 2,
-    },
-    {
-      payer,
-      systemProgram: SYSTEM_PROGRAM_ADDRESS,
-    },
-    [
-      { address: remainingAddress1, role: AccountRole.READONLY },
-      { address: remainingAddress2, role: AccountRole.READONLY },
-    ],
-  )])
-})
-
-it("remaining accounts should throw", async () => {
-  const payer = await createKeyPairSignerFromBytes(Uint8Array.from(faucet))
-
-  try {
-    await sendTx(payer, [remaining(
+  await sendTx(payer, [
+    remaining(
       {
         expectedRemainingAccounts: 2,
       },
@@ -1213,20 +1199,42 @@ it("remaining accounts should throw", async () => {
         payer,
         systemProgram: SYSTEM_PROGRAM_ADDRESS,
       },
-    )])
+      [
+        { address: remainingAddress1, role: AccountRole.READONLY },
+        { address: remainingAddress2, role: AccountRole.READONLY },
+      ]
+    ),
+  ])
+})
+
+it("remaining accounts should throw", async () => {
+  const payer = await createKeyPairSignerFromBytes(Uint8Array.from(faucet))
+
+  try {
+    await sendTx(payer, [
+      remaining(
+        {
+          expectedRemainingAccounts: 2,
+        },
+        {
+          payer,
+          systemProgram: SYSTEM_PROGRAM_ADDRESS,
+        }
+      ),
+    ])
   } catch (e) {
-      const parsed = fromTxError(e)
+    const parsed = fromTxError(e)
 
-      expect(parsed).not.toBe(null)
-      if (parsed === null) {
-        throw new Error()
-      }
+    expect(parsed).not.toBe(null)
+    if (parsed === null) {
+      throw new Error()
+    }
 
-      expect(parsed.message).toBe("6003: Remaining accounts mismatch.")
-      expect(parsed.code).toBe(6003)
-      expect(parsed.name).toBe("RemainingAccountsMismatch")
-      expect("msg" in parsed && parsed.msg).toBe("Remaining accounts mismatch.")
-      return
+    expect(parsed.message).toBe("6003: Remaining accounts mismatch.")
+    expect(parsed.code).toBe(6003)
+    expect(parsed.name).toBe("RemainingAccountsMismatch")
+    expect("msg" in parsed && parsed.msg).toBe("Remaining accounts mismatch.")
+    return
   }
 })
 

--- a/tests/test.ts
+++ b/tests/test.ts
@@ -677,7 +677,7 @@ it("tx error", async () => {
       "Program 3rTQ3R4B2PxZrAyx7EUefySPgZY8RhJf16cZajbmrzp8 invoke [1]",
       "Program log: Instruction: CauseError",
       "Program log: AnchorError thrown in programs/example-program/src/lib.rs:90. Error Code: SomeError. Error Number: 6000. Error Message: Example error..",
-      "Program 3rTQ3R4B2PxZrAyx7EUefySPgZY8RhJf16cZajbmrzp8 consumed 2016 of 200000 compute units",
+      "Program 3rTQ3R4B2PxZrAyx7EUefySPgZY8RhJf16cZajbmrzp8 consumed 2043 of 200000 compute units",
       "Program 3rTQ3R4B2PxZrAyx7EUefySPgZY8RhJf16cZajbmrzp8 failed: custom program error: 0x1770",
     ])
 


### PR DESCRIPTION
This patch allows to pass variable accounts into instructions similar to the coral anchor client.

Codegen example before patch:
```ts
export function play(
  args: PlayArgs,
  accounts: PlayAccounts,
  programAddress: Address = PROGRAM_ID
) {
  const keys: Array<IAccountMeta | IAccountSignerMeta> = [
    { address: accounts.game, role: 1 },
    { address: accounts.player.address, role: 2, signer: accounts.player },
  ]
  const identifier = Buffer.from([213, 157, 193, 142, 228, 56, 248, 150])
  const buffer = Buffer.alloc(1000)
  const len = layout.encode(
    {
      tile: types.Tile.toEncodable(args.tile),
    },
    buffer
  )
  const data = Buffer.concat([identifier, buffer]).slice(0, 8 + len)
  const ix: IInstruction = { accounts: keys, programAddress, data }
  return ix
}
```

Codegen example after patch:
```ts
export function play(
  args: PlayArgs,
  accounts: PlayAccounts,
  remainingAccounts: Array<IAccountMeta | IAccountSignerMeta> = [],
  programAddress: Address = PROGRAM_ID
) {
  const keys: Array<IAccountMeta | IAccountSignerMeta> = [
    { address: accounts.game, role: 1 },
    { address: accounts.player.address, role: 2, signer: accounts.player },
    ...remainingAccounts,
  ]
  const identifier = Buffer.from([213, 157, 193, 142, 228, 56, 248, 150])
  const buffer = Buffer.alloc(1000)
  const len = layout.encode(
    {
      tile: types.Tile.toEncodable(args.tile),
    },
    buffer
  )
  const data = Buffer.concat([identifier, buffer]).slice(0, 8 + len)
  const ix: IInstruction = { accounts: keys, programAddress, data }
  return ix
}
```