### PR TITLE
Add props-style arguments to instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,13 +96,16 @@ const fooAccount = generateKeyPairSigner()
 
 // call an instruction
 const ix = someInstruction({
-  fooParam: "...",
-  barParam: "...",
-  ...
-}, {
-  fooAccount: fooAccount, // signer
-  barAccount: address("..."),
-  ...
+  args: {
+    fooParam: "...",
+    barParam: "...",
+    ...
+  },
+  accounts: {
+    fooAccount: fooAccount, // signer
+    barAccount: address("..."),
+    ...
+  }
 })
 
 const blockhash = await rpc
@@ -190,24 +193,30 @@ console.log(tupleEnum.toJSON(), structEnum.toJSON(), discEnum.toJSON())
 ```ts
 // types are used as arguments in instruction calls (where needed):
 const ix = someInstruction({
-  someStructField: barStruct,
-  someEnumField: tupleEnum,
-  ...
-}, {
-  // accounts
-  ...
+  args: {
+    someStructField: barStruct,
+    someEnumField: tupleEnum,
+    ...
+  },
+  accounts: {
+    // accounts
+    ...
+  }
 })
 
 // in case of struct fields, it's also possible to pass them as objects:
-const ix = someInstrution({
-  someStructField: {
-    someField: "...",
-    otherField: "...",
+const ix2 = someInstrution({
+  args: {
+    someStructField: {
+      someField: "...",
+      otherField: "...",
+    },
+    ...,
   },
-  ...,
-}, {
-  // accounts
-  ...
+  accounts: {
+    // accounts
+    ...
+  }
 })
 ```
 

--- a/examples/basic-2/generated-client/instructions/create.ts
+++ b/examples/basic-2/generated-client/instructions/create.ts
@@ -27,12 +27,21 @@ export interface CreateAccounts {
 
 export const layout = borsh.struct([borshAddress("authority")])
 
-export function create(
-  args: CreateArgs,
-  accounts: CreateAccounts,
-  remainingAccounts: Array<AccountMeta | AccountSignerMeta> = [],
-  programAddress: Address = PROGRAM_ID
-) {
+export interface CreateProps {
+  args: CreateArgs
+  accounts: CreateAccounts
+  /** @default [] */
+  remainingAccounts?: Array<AccountMeta | AccountSignerMeta>
+  /** @default PROGRAM_ID */
+  programAddress?: Address
+}
+
+export function create({
+  args,
+  accounts,
+  remainingAccounts = [],
+  programAddress = PROGRAM_ID,
+}: CreateProps) {
   const keys: Array<AccountMeta | AccountSignerMeta> = [
     { address: accounts.counter.address, role: 3, signer: accounts.counter },
     { address: accounts.user.address, role: 3, signer: accounts.user },

--- a/examples/basic-2/generated-client/instructions/increment.ts
+++ b/examples/basic-2/generated-client/instructions/increment.ts
@@ -20,11 +20,19 @@ export interface IncrementAccounts {
   authority: TransactionSigner
 }
 
-export function increment(
-  accounts: IncrementAccounts,
-  remainingAccounts: Array<AccountMeta | AccountSignerMeta> = [],
-  programAddress: Address = PROGRAM_ID
-) {
+export interface IncrementProps {
+  accounts: IncrementAccounts
+  /** @default [] */
+  remainingAccounts?: Array<AccountMeta | AccountSignerMeta>
+  /** @default PROGRAM_ID */
+  programAddress?: Address
+}
+
+export function increment({
+  accounts,
+  remainingAccounts = [],
+  programAddress = PROGRAM_ID,
+}: IncrementProps) {
   const keys: Array<AccountMeta | AccountSignerMeta> = [
     { address: accounts.counter, role: 1 },
     {

--- a/examples/tic-tac-toe/generated-client/instructions/play.ts
+++ b/examples/tic-tac-toe/generated-client/instructions/play.ts
@@ -29,12 +29,21 @@ export interface PlayAccounts {
 
 export const layout = borsh.struct([types.Tile.layout("tile")])
 
-export function play(
-  args: PlayArgs,
-  accounts: PlayAccounts,
-  remainingAccounts: Array<AccountMeta | AccountSignerMeta> = [],
-  programAddress: Address = PROGRAM_ID
-) {
+export interface PlayProps {
+  args: PlayArgs
+  accounts: PlayAccounts
+  /** @default [] */
+  remainingAccounts?: Array<AccountMeta | AccountSignerMeta>
+  /** @default PROGRAM_ID */
+  programAddress?: Address
+}
+
+export function play({
+  args,
+  accounts,
+  remainingAccounts = [],
+  programAddress = PROGRAM_ID,
+}: PlayProps) {
   const keys: Array<AccountMeta | AccountSignerMeta> = [
     { address: accounts.game, role: 1 },
     { address: accounts.player.address, role: 2, signer: accounts.player },

--- a/examples/tic-tac-toe/generated-client/instructions/setupGame.ts
+++ b/examples/tic-tac-toe/generated-client/instructions/setupGame.ts
@@ -30,12 +30,21 @@ export interface SetupGameAccounts {
 
 export const layout = borsh.struct([borshAddress("playerTwo")])
 
-export function setupGame(
-  args: SetupGameArgs,
-  accounts: SetupGameAccounts,
-  remainingAccounts: Array<AccountMeta | AccountSignerMeta> = [],
-  programAddress: Address = PROGRAM_ID
-) {
+export interface SetupGameProps {
+  args: SetupGameArgs
+  accounts: SetupGameAccounts
+  /** @default [] */
+  remainingAccounts?: Array<AccountMeta | AccountSignerMeta>
+  /** @default PROGRAM_ID */
+  programAddress?: Address
+}
+
+export function setupGame({
+  args,
+  accounts,
+  remainingAccounts = [],
+  programAddress = PROGRAM_ID,
+}: SetupGameProps) {
   const keys: Array<AccountMeta | AccountSignerMeta> = [
     { address: accounts.game.address, role: 3, signer: accounts.game },
     {

--- a/tests/example-program-gen/exp/instructions/causeError.ts
+++ b/tests/example-program-gen/exp/instructions/causeError.ts
@@ -16,10 +16,17 @@ import { PROGRAM_ID } from "../programId"
 
 export const DISCRIMINATOR = new Uint8Array([67, 104, 37, 17, 2, 155, 68, 17])
 
-export function causeError(
-  remainingAccounts: Array<AccountMeta | AccountSignerMeta> = [],
-  programAddress: Address = PROGRAM_ID
-) {
+export interface CauseErrorProps {
+  /** @default [] */
+  remainingAccounts?: Array<AccountMeta | AccountSignerMeta>
+  /** @default PROGRAM_ID */
+  programAddress?: Address
+}
+
+export function causeError({
+  remainingAccounts = [],
+  programAddress = PROGRAM_ID,
+}: CauseErrorProps = {}) {
   const keys: Array<AccountMeta | AccountSignerMeta> = [...remainingAccounts]
   const data = DISCRIMINATOR
   const ix: Instruction = { accounts: keys, programAddress, data }

--- a/tests/example-program-gen/exp/instructions/initialize.ts
+++ b/tests/example-program-gen/exp/instructions/initialize.ts
@@ -30,11 +30,19 @@ export interface InitializeAccounts {
   systemProgram: Address
 }
 
-export function initialize(
-  accounts: InitializeAccounts,
-  remainingAccounts: Array<AccountMeta | AccountSignerMeta> = [],
-  programAddress: Address = PROGRAM_ID
-) {
+export interface InitializeProps {
+  accounts: InitializeAccounts
+  /** @default [] */
+  remainingAccounts?: Array<AccountMeta | AccountSignerMeta>
+  /** @default PROGRAM_ID */
+  programAddress?: Address
+}
+
+export function initialize({
+  accounts,
+  remainingAccounts = [],
+  programAddress = PROGRAM_ID,
+}: InitializeProps) {
   const keys: Array<AccountMeta | AccountSignerMeta> = [
     { address: accounts.state.address, role: 3, signer: accounts.state },
     { address: accounts.nested.clock, role: 0 },

--- a/tests/example-program-gen/exp/instructions/initializeWithValues.ts
+++ b/tests/example-program-gen/exp/instructions/initializeWithValues.ts
@@ -91,12 +91,22 @@ export const layout = borsh.struct([
 ])
 
 /** Initializes an account with specified values */
-export function initializeWithValues(
-  args: InitializeWithValuesArgs,
-  accounts: InitializeWithValuesAccounts,
-  remainingAccounts: Array<AccountMeta | AccountSignerMeta> = [],
-  programAddress: Address = PROGRAM_ID
-) {
+export interface InitializeWithValuesProps {
+  args: InitializeWithValuesArgs
+  accounts: InitializeWithValuesAccounts
+  /** @default [] */
+  remainingAccounts?: Array<AccountMeta | AccountSignerMeta>
+  /** @default PROGRAM_ID */
+  programAddress?: Address
+}
+
+/** Initializes an account with specified values */
+export function initializeWithValues({
+  args,
+  accounts,
+  remainingAccounts = [],
+  programAddress = PROGRAM_ID,
+}: InitializeWithValuesProps) {
   const keys: Array<AccountMeta | AccountSignerMeta> = [
     { address: accounts.state.address, role: 3, signer: accounts.state },
     { address: accounts.nested.clock, role: 0 },

--- a/tests/example-program-gen/exp/instructions/initializeWithValues2.ts
+++ b/tests/example-program-gen/exp/instructions/initializeWithValues2.ts
@@ -36,12 +36,25 @@ export const layout = borsh.struct([
  * a separate instruction due to initialize_with_values having too many arguments
  * https://github.com/solana-labs/solana/issues/23978
  */
-export function initializeWithValues2(
-  args: InitializeWithValues2Args,
-  accounts: InitializeWithValues2Accounts,
-  remainingAccounts: Array<AccountMeta | AccountSignerMeta> = [],
-  programAddress: Address = PROGRAM_ID
-) {
+export interface InitializeWithValues2Props {
+  args: InitializeWithValues2Args
+  accounts: InitializeWithValues2Accounts
+  /** @default [] */
+  remainingAccounts?: Array<AccountMeta | AccountSignerMeta>
+  /** @default PROGRAM_ID */
+  programAddress?: Address
+}
+
+/**
+ * a separate instruction due to initialize_with_values having too many arguments
+ * https://github.com/solana-labs/solana/issues/23978
+ */
+export function initializeWithValues2({
+  args,
+  accounts,
+  remainingAccounts = [],
+  programAddress = PROGRAM_ID,
+}: InitializeWithValues2Props) {
   const keys: Array<AccountMeta | AccountSignerMeta> = [
     { address: accounts.state.address, role: 3, signer: accounts.state },
     { address: accounts.payer.address, role: 3, signer: accounts.payer },

--- a/tests/example-program-gen/exp/instructions/optional.ts
+++ b/tests/example-program-gen/exp/instructions/optional.ts
@@ -28,11 +28,19 @@ export interface OptionalAccounts {
   systemProgram: Address
 }
 
-export function optional(
-  accounts: OptionalAccounts,
-  remainingAccounts: Array<AccountMeta | AccountSignerMeta> = [],
-  programAddress: Address = PROGRAM_ID
-) {
+export interface OptionalProps {
+  accounts: OptionalAccounts
+  /** @default [] */
+  remainingAccounts?: Array<AccountMeta | AccountSignerMeta>
+  /** @default PROGRAM_ID */
+  programAddress?: Address
+}
+
+export function optional({
+  accounts,
+  remainingAccounts = [],
+  programAddress = PROGRAM_ID,
+}: OptionalProps) {
   const keys: Array<AccountMeta | AccountSignerMeta> = [
     {
       address: accounts.optionalState.address,

--- a/tests/example-program-gen/exp/instructions/remaining.ts
+++ b/tests/example-program-gen/exp/instructions/remaining.ts
@@ -29,12 +29,21 @@ export interface RemainingAccounts {
 
 export const layout = borsh.struct([borsh.u32("expectedRemainingAccounts")])
 
-export function remaining(
-  args: RemainingArgs,
-  accounts: RemainingAccounts,
-  remainingAccounts: Array<AccountMeta | AccountSignerMeta> = [],
-  programAddress: Address = PROGRAM_ID
-) {
+export interface RemainingProps {
+  args: RemainingArgs
+  accounts: RemainingAccounts
+  /** @default [] */
+  remainingAccounts?: Array<AccountMeta | AccountSignerMeta>
+  /** @default PROGRAM_ID */
+  programAddress?: Address
+}
+
+export function remaining({
+  args,
+  accounts,
+  remainingAccounts = [],
+  programAddress = PROGRAM_ID,
+}: RemainingProps) {
   const keys: Array<AccountMeta | AccountSignerMeta> = [
     { address: accounts.payer.address, role: 3, signer: accounts.payer },
     { address: accounts.systemProgram, role: 0 },

--- a/tests/test.spec.ts
+++ b/tests/test.spec.ts
@@ -87,13 +87,15 @@ it("init and account fetch", async () => {
 
   await sendTx(payer, [
     initialize({
-      state: state,
-      payer: payer,
-      nested: {
-        clock: SYSVAR_CLOCK_ADDRESS,
-        rent: SYSVAR_RENT_ADDRESS,
+      accounts: {
+        state: state,
+        payer: payer,
+        nested: {
+          clock: SYSVAR_CLOCK_ADDRESS,
+          rent: SYSVAR_RENT_ADDRESS,
+        },
+        systemProgram: SYSTEM_PROGRAM_ADDRESS,
       },
-      systemProgram: SYSTEM_PROGRAM_ADDRESS,
     }),
   ])
   const res = await State.fetch(rpc, state.address)
@@ -254,22 +256,26 @@ it("fetch multiple", async () => {
 
   await sendTx(payer, [
     initialize({
-      state: state,
-      payer: payer,
-      nested: {
-        clock: SYSVAR_CLOCK_ADDRESS,
-        rent: SYSVAR_RENT_ADDRESS,
+      accounts: {
+        state: state,
+        payer: payer,
+        nested: {
+          clock: SYSVAR_CLOCK_ADDRESS,
+          rent: SYSVAR_RENT_ADDRESS,
+        },
+        systemProgram: SYSTEM_PROGRAM_ADDRESS,
       },
-      systemProgram: SYSTEM_PROGRAM_ADDRESS,
     }),
     initialize({
-      state: another_state,
-      payer: payer,
-      nested: {
-        clock: SYSVAR_CLOCK_ADDRESS,
-        rent: SYSVAR_RENT_ADDRESS,
+      accounts: {
+        state: another_state,
+        payer: payer,
+        nested: {
+          clock: SYSVAR_CLOCK_ADDRESS,
+          rent: SYSVAR_RENT_ADDRESS,
+        },
+        systemProgram: SYSTEM_PROGRAM_ADDRESS,
       },
-      systemProgram: SYSTEM_PROGRAM_ADDRESS,
     }),
   ])
 
@@ -288,8 +294,8 @@ it("instruction with args", async () => {
   const state2 = await generateKeyPairSigner()
 
   await sendTx(payer, [
-    initializeWithValues(
-      {
+    initializeWithValues({
+      args: {
         boolField: true,
         u8Field: 253,
         i8Field: -120,
@@ -382,7 +388,7 @@ it("instruction with args", async () => {
         enumField4: new NoFields(),
         cStyleEnumField: new Second(),
       },
-      {
+      accounts: {
         state: state,
         payer: payer,
         nested: {
@@ -390,18 +396,18 @@ it("instruction with args", async () => {
           rent: SYSVAR_RENT_ADDRESS,
         },
         systemProgram: SYSTEM_PROGRAM_ADDRESS,
-      }
-    ),
-    initializeWithValues2(
-      {
+      },
+    }),
+    initializeWithValues2({
+      args: {
         vecOfOption: [null, 20n],
       },
-      {
+      accounts: {
         state: state2,
         payer: payer,
         systemProgram: SYSTEM_PROGRAM_ADDRESS,
-      }
-    ),
+      },
+    }),
   ])
 
   const res = await State.fetch(rpc, state.address)
@@ -564,13 +570,15 @@ it("optional with some readonly signer", async () => {
 
   await sendTx(payer, [
     optional({
-      optionalState,
-      readonlySignerOption: some(signer),
-      mutableSignerOption: none(),
-      readonlyOption: none(),
-      mutableOption: none(),
-      payer,
-      systemProgram: SYSTEM_PROGRAM_ADDRESS,
+      accounts: {
+        optionalState,
+        readonlySignerOption: some(signer),
+        mutableSignerOption: none(),
+        readonlyOption: none(),
+        mutableOption: none(),
+        payer,
+        systemProgram: SYSTEM_PROGRAM_ADDRESS,
+      },
     }),
   ])
 
@@ -589,13 +597,15 @@ it("optional with some mutable signer", async () => {
 
   await sendTx(payer, [
     optional({
-      optionalState,
-      readonlySignerOption: none(),
-      mutableSignerOption: some(signer),
-      readonlyOption: none(),
-      mutableOption: none(),
-      payer,
-      systemProgram: SYSTEM_PROGRAM_ADDRESS,
+      accounts: {
+        optionalState,
+        readonlySignerOption: none(),
+        mutableSignerOption: some(signer),
+        readonlyOption: none(),
+        mutableOption: none(),
+        payer,
+        systemProgram: SYSTEM_PROGRAM_ADDRESS,
+      },
     }),
   ])
 
@@ -614,13 +624,15 @@ it("optional with some readonly account", async () => {
 
   await sendTx(payer, [
     optional({
-      optionalState,
-      readonlySignerOption: none(),
-      mutableSignerOption: none(),
-      readonlyOption: some(signer.address),
-      mutableOption: none(),
-      payer,
-      systemProgram: SYSTEM_PROGRAM_ADDRESS,
+      accounts: {
+        optionalState,
+        readonlySignerOption: none(),
+        mutableSignerOption: none(),
+        readonlyOption: some(signer.address),
+        mutableOption: none(),
+        payer,
+        systemProgram: SYSTEM_PROGRAM_ADDRESS,
+      },
     }),
   ])
 
@@ -639,13 +651,15 @@ it("optional with some mutable account", async () => {
 
   await sendTx(payer, [
     optional({
-      optionalState,
-      readonlySignerOption: none(),
-      mutableSignerOption: none(),
-      readonlyOption: none(),
-      mutableOption: some(signer.address),
-      payer,
-      systemProgram: SYSTEM_PROGRAM_ADDRESS,
+      accounts: {
+        optionalState,
+        readonlySignerOption: none(),
+        mutableSignerOption: none(),
+        readonlyOption: none(),
+        mutableOption: some(signer.address),
+        payer,
+        systemProgram: SYSTEM_PROGRAM_ADDRESS,
+      },
     }),
   ])
 
@@ -1198,19 +1212,19 @@ it("remaining accounts should match", async () => {
   )
 
   await sendTx(payer, [
-    remaining(
-      {
+    remaining({
+      args: {
         expectedRemainingAccounts: 2,
       },
-      {
+      accounts: {
         payer,
         systemProgram: SYSTEM_PROGRAM_ADDRESS,
       },
-      [
+      remainingAccounts: [
         { address: remainingAddress1, role: AccountRole.READONLY },
         { address: remainingAddress2, role: AccountRole.READONLY },
-      ]
-    ),
+      ],
+    }),
   ])
 })
 
@@ -1219,15 +1233,15 @@ it("remaining accounts should throw", async () => {
 
   try {
     await sendTx(payer, [
-      remaining(
-        {
+      remaining({
+        args: {
           expectedRemainingAccounts: 2,
         },
-        {
+        accounts: {
           payer,
           systemProgram: SYSTEM_PROGRAM_ADDRESS,
-        }
-      ),
+        },
+      }),
     ])
   } catch (e) {
     const parsed = fromTxError(e)


### PR DESCRIPTION
Since https://github.com/kklas/anchor-client-gen/pull/71 was added, there are up to 4 parameters to initialize an instruction, 2 of these (`programAddress` and `remainingAccounts`) are always optional, so it makes sense to make a props-style arguments object.

### Old

```ts
const ix = initializeWithValues2(
  {
    vecOfOption: [null, new BN(20)],
  },
  {
    state: state2,
    payer: payer,
    systemProgram: SYSTEM_PROGRAM_ADDRESS,
  },
  [..]
  address('dddf'),
)
```


### New

```ts
const ix = initializeWithValues2({
  args: {
    vecOfOption: [null, new BN(20)],
  },
  accounts: {
    state: state2,
    payer: payer,
    systemProgram: SYSTEM_PROGRAM_ADDRESS,
  },
  remainingAccounts: [..],
  programAddress: address('dddf')
})
```